### PR TITLE
[feat] 공통 컴포넌트: 좌우 스크롤 구현 

### DIFF
--- a/src/components/HorizontalScroll/HorizontalScroll.style.ts
+++ b/src/components/HorizontalScroll/HorizontalScroll.style.ts
@@ -12,10 +12,10 @@ export const classItemStyle = css`
   flex-shrink: 0;
 `;
 
-export const firstClassItemStyle = (sideMargin: string) => css`
-  padding-left: ${sideMargin};
+export const firstClassItemStyle = (sidePadding: string) => css`
+  padding-left: ${sidePadding};
 `;
 
-export const lastClassItemStyle = (sideMargin: string) => css`
-  padding-right: ${sideMargin};
+export const lastClassItemStyle = (sidePadding: string) => css`
+  padding-right: ${sidePadding};
 `;

--- a/src/components/HorizontalScroll/HorizontalScroll.style.ts
+++ b/src/components/HorizontalScroll/HorizontalScroll.style.ts
@@ -5,7 +5,11 @@ export const rowScrollStyle = (gap: string) => css`
   flex-direction: row;
   gap: ${gap};
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const classItemStyle = css`

--- a/src/components/HorizontalScroll/HorizontalScroll.style.ts
+++ b/src/components/HorizontalScroll/HorizontalScroll.style.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+
+export const rowScrollStyle = (gap: string) => css`
+  display: flex;
+  flex-direction: row;
+  gap: ${gap};
+  overflow-x: auto;
+  scrollbar-width: none;
+`;
+
+export const classItemStyle = css`
+  flex-shrink: 0;
+`;
+
+export const firstClassItemStyle = (sideMargin: string) => css`
+  padding-left: ${sideMargin};
+`;
+
+export const lastClassItemStyle = (sideMargin: string) => css`
+  padding-right: ${sideMargin};
+`;

--- a/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+
+import {
+  rowScrollStyle,
+  classItemStyle,
+  firstClassItemStyle,
+  lastClassItemStyle,
+} from '@/components/HorizontalScroll/HorizontalScroll.style';
+
+interface HorizontalScrollListProps {
+  children: ReactNode[];
+  gap?: string;
+  sideMargin?: string;
+}
+
+const HorizontalScrollList = ({
+  children,
+  gap = '1.6rem',
+  sideMargin = '2.4rem',
+}: HorizontalScrollListProps) => {
+  return (
+    <div css={rowScrollStyle(gap)}>
+      {children.map((child, index) => {
+        const isFirst = index === 0;
+        const isLast = index === children.length - 1;
+
+        return (
+          <div
+            key={index}
+            css={[
+              classItemStyle,
+              isFirst && firstClassItemStyle(sideMargin),
+              isLast && lastClassItemStyle(sideMargin),
+            ]}
+          >
+            {child}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default HorizontalScrollList;

--- a/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -1,11 +1,6 @@
 import type { ReactNode } from 'react';
 
-import {
-  rowScrollStyle,
-  classItemStyle,
-  firstClassItemStyle,
-  lastClassItemStyle,
-} from '@/components/HorizontalScroll/HorizontalScroll.style';
+import * as s from '@/components/HorizontalScroll/HorizontalScroll.style';
 
 interface HorizontalScrollPropTypes {
   children: ReactNode[];
@@ -19,7 +14,7 @@ const HorizontalScrollList = ({
   sidePadding = '2.4rem',
 }: HorizontalScrollPropTypes) => {
   return (
-    <div css={rowScrollStyle(gap)}>
+    <div css={s.rowScrollStyle(gap)}>
       {children.map((child, index) => {
         const isFirst = index === 0;
         const isLast = index === children.length - 1;
@@ -28,9 +23,9 @@ const HorizontalScrollList = ({
           <div
             key={index}
             css={[
-              classItemStyle,
-              isFirst && firstClassItemStyle(sidePadding),
-              isLast && lastClassItemStyle(sidePadding),
+              s.classItemStyle,
+              isFirst && s.firstClassItemStyle(sidePadding),
+              isLast && s.lastClassItemStyle(sidePadding),
             ]}
           >
             {child}

--- a/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -7,17 +7,17 @@ import {
   lastClassItemStyle,
 } from '@/components/HorizontalScroll/HorizontalScroll.style';
 
-interface HorizontalScrollListProps {
+interface HorizontalScrollPropTypes {
   children: ReactNode[];
   gap?: string;
-  sideMargin?: string;
+  sidePadding?: string;
 }
 
 const HorizontalScrollList = ({
   children,
   gap = '1.6rem',
-  sideMargin = '2.4rem',
-}: HorizontalScrollListProps) => {
+  sidePadding = '2.4rem',
+}: HorizontalScrollPropTypes) => {
   return (
     <div css={rowScrollStyle(gap)}>
       {children.map((child, index) => {
@@ -29,8 +29,8 @@ const HorizontalScrollList = ({
             key={index}
             css={[
               classItemStyle,
-              isFirst && firstClassItemStyle(sideMargin),
-              isLast && lastClassItemStyle(sideMargin),
+              isFirst && firstClassItemStyle(sidePadding),
+              isLast && lastClassItemStyle(sidePadding),
             ]}
           >
             {child}


### PR DESCRIPTION
<!-- PR 제목은 '[feat] 작업 내용' 형태로 작성해주세요. -->

## 📌 이슈 번호
- close #25

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR 템플릿 작성
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 구현 사항
- 이번 프로젝트에서 좌우 스크롤 UI가 빈번해, 이를 재사용 가능하도록 좌우 스크롤 공통 컴포넌트를 만들었습니다.
- 이 컴포넌트는 기본적으로 카드 사이 gap을 '1.6rem'로 설정하며,
- 첫 번째 카드에는 왼쪽 sidePadding을, 마지막 카드에는 오른쪽 sidePadding을 동일하게 주는데, 기본값은 '2.4rem'입니다.
- gap과 sidePadding은 props로 받아 원하는 값으로 쉽게 조절할 수 있습니다.

```ts
      <HorizontalScroll gap="1rem" sidePadding="1rem">
        <Card imgUrl={sampleImage} title="행동하지 않으면 인생은 바뀌지 않는다" type="square" />
        <Card imgUrl={sampleImage} title="행동하지 않으면 인생은 바뀌지 않는다" type="square" />
        <Card imgUrl={sampleImage} title="행동하지 않으면 인생은 바뀌지 않는다" type="square" />
        <Card imgUrl={sampleImage} title="첫 여름, 완주" type="rectangular" />
        <Card imgUrl={sampleImage} title="첫 여름, 완주" type="rectangular" />
      </HorizontalScroll>
```
- 단순히 첫 요소의 왼쪽 padding과 마지막 요소의 오른쪽 padding, gap만 설정해주어서 앞으로 추가로 만들 카드 컴포넌트들 모두 `<HorizontalScoll> ... </HorizontalScoll> `사이에 넣어주면 됩니다..!

## 🔍 Review Point
<!-- 리뷰어가 집중해야 할 부분이나 해당 PR에서 논의가 필요한 사항을 적어주세요! -->
- 최대한 사용하기 편하게 .. 만들기 위해 노력했는데, <HorizontalScrollList gap="1rem" sidePadding="1rem"> 이 정도면 직관적이고 잘 사용하실 것 같나요?!


## 📸 Screenshot
![스크린샷 2025-05-16 015151](https://github.com/user-attachments/assets/a52049ab-d499-482e-8b8a-b9c76d501d72)

![스크린샷 2025-05-16 015145](https://github.com/user-attachments/assets/bcd8be10-eb3b-42c5-9057-bdae575f8375)

<!--
## 🔗 Reference
참고한 문서가 있다면 공유해주세요. 아티클 작성도 환영!
-->