### PR TITLE
[feat] HomeBestDetailCart 페이지 Api 연동

### DIFF
--- a/src/components/BottomNav/CartBottomNav.tsx
+++ b/src/components/BottomNav/CartBottomNav.tsx
@@ -2,15 +2,18 @@ import { useTheme } from '@emotion/react';
 
 import { CartBottomNavStyle as s } from '@/components/BottomNav/CartBottomNav.style';
 
-const CartBottomNav = () => {
+interface CartBottomNavProps {
+  totalPrice: number;
+}
+
+const CartBottomNav = ({ totalPrice }: CartBottomNavProps) => {
   const theme = useTheme();
-  const Price = 15120;
 
   return (
     <div css={s.wrapper(theme)}>
       <div css={s.priceWrapper}>
         <span css={s.label(theme)}>결제 예정 금액</span>
-        <span css={s.amount(theme)}>{Price.toLocaleString()}원</span>
+        <span css={s.amount(theme)}>{totalPrice.toLocaleString()}원</span>
       </div>
       <button css={s.purchaseButton(theme)}>구매하기</button>
     </div>

--- a/src/components/BottomNav/DetailBottomNav.tsx
+++ b/src/components/BottomNav/DetailBottomNav.tsx
@@ -4,19 +4,20 @@ import { useTheme } from '@emotion/react';
 
 import { DetailBottomNavStyle as s } from '@/components/BottomNav/DetailBottomNav.style';
 import Icon from '@/components/Icon';
-import routePath from '@/routes/routePath';
+import { useBookId } from '@/utils/useBookId';
 
 const DetailBottomNav = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const [liked, setLiked] = useState(false);
+  const bookId = useBookId();
 
   const handleLikeToggle = () => {
     setLiked((prev) => !prev);
   };
 
   const handleGoToCart = () => {
-    navigate(routePath.HOME_BEST_DETAIL_CART);
+    navigate(`/best/detail-cart/${bookId}`);
   };
 
   return (

--- a/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.style.ts
+++ b/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.style.ts
@@ -19,6 +19,8 @@ const topWrapper = (theme: Theme) => css`
   border-bottom: 1px solid ${theme.colors.gray2};
 `;
 
+const imageStyle = () => css``;
+
 const Banner = css`
   display: flex;
   justify-content: space-between;
@@ -111,15 +113,16 @@ const cardHeader = css`
   justify-content: space-between;
 `;
 
-const bookTag = (theme: Theme) => css`
+const bookTag = () => css`
   display: flex;
   gap: 0.5rem;
   align-items: center;
   justify-content: space-between;
-  .title {
-    font: ${theme.fonts.body1};
-    color: ${theme.colors.black1};
-  }
+`;
+
+const titleText = (theme: Theme) => css`
+  font: ${theme.fonts.body1};
+  color: ${theme.colors.black1};
 `;
 
 const cardBody = (theme: Theme) => css`
@@ -230,6 +233,7 @@ export const FirstCartViewStyle = {
   Wrapper,
   firstBox,
   topWrapper,
+  imageStyle,
   Banner,
   bannerTop,
   iconButton,
@@ -241,6 +245,7 @@ export const FirstCartViewStyle = {
   Card,
   cardHeader,
   bookTag,
+  titleText,
   cardBody,
   footerButton,
   Chip,

--- a/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.style.ts
+++ b/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.style.ts
@@ -220,9 +220,21 @@ const footerButton = (theme: Theme) => css`
 
 const Chip = (theme: Theme) => css`
   padding: 0.125rem 0.5rem;
-  font: ${theme.fonts.caption1};
+  font: ${theme.fonts.caption3};
   color: ${theme.colors.purple7};
   background-color: ${theme.colors.purple1};
+  border-radius: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const secondChip = (theme: Theme) => css`
+  padding: 0.125rem 0.5rem;
+  font: ${theme.fonts.caption3};
+  color: ${theme.colors.purple6};
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.purple6};
   border-radius: 40px;
   display: inline-flex;
   align-items: center;
@@ -249,4 +261,5 @@ export const FirstCartViewStyle = {
   cardBody,
   footerButton,
   Chip,
+  secondChip,
 };

--- a/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.tsx
+++ b/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.tsx
@@ -103,7 +103,7 @@ const FirstCartView = ({ bookData }: BookDetailProps) => {
                 <span>오늘(4/24, 목) 도착</span>
               </div>
               <div className="line">
-                <span css={s.Chip}>바로드림</span>
+                <span css={s.secondChip}>바로드림</span>
                 <span>9시간 이후 수령 가능</span>
               </div>
             </div>

--- a/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.tsx
+++ b/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { FirstCartViewStyle as s } from './FirstCartView.style';
 
@@ -7,9 +7,10 @@ import type { BookDetailResponse } from '@/types/bookDetailTypes';
 
 interface BookDetailProps {
   bookData?: BookDetailResponse;
+  onTotalPriceChange?: (price: number) => void;
 }
 
-const FirstCartView = ({ bookData }: BookDetailProps) => {
+const FirstCartView = ({ bookData, onTotalPriceChange }: BookDetailProps) => {
   const [count, setCount] = useState(1);
   const MAX_COUNT = 10;
   const discountedUnitPrice = Number(bookData?.price?.replace('원', '') ?? '0');
@@ -21,6 +22,12 @@ const FirstCartView = ({ bookData }: BookDetailProps) => {
   const originalTotalPrice = originalUnitPrice * count;
 
   const totalPoint = Math.floor(discountedTotalPrice * 0.05);
+
+  useEffect(() => {
+    if (onTotalPriceChange) {
+      onTotalPriceChange(discountedTotalPrice);
+    }
+  }, [discountedTotalPrice, onTotalPriceChange]);
 
   const handleDecrease = () => {
     if (count > 1) {

--- a/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.tsx
+++ b/src/pages/HomeBestDetailCart/FirstCartView/FirstCartView.tsx
@@ -3,12 +3,24 @@ import { useState } from 'react';
 import { FirstCartViewStyle as s } from './FirstCartView.style';
 
 import Icon from '@/components/Icon';
+import type { BookDetailResponse } from '@/types/bookDetailTypes';
 
-const FirstCartView = () => {
+interface BookDetailProps {
+  bookData?: BookDetailResponse;
+}
+
+const FirstCartView = ({ bookData }: BookDetailProps) => {
   const [count, setCount] = useState(1);
   const MAX_COUNT = 10;
-  const price = 16800;
-  const point = 840;
+  const discountedUnitPrice = Number(bookData?.price?.replace('원', '') ?? '0');
+
+  const originalUnitPrice = Math.floor(discountedUnitPrice / 0.9);
+
+  const discountedTotalPrice = discountedUnitPrice * count;
+
+  const originalTotalPrice = originalUnitPrice * count;
+
+  const totalPoint = Math.floor(discountedTotalPrice * 0.05);
 
   const handleDecrease = () => {
     if (count > 1) {
@@ -21,9 +33,6 @@ const FirstCartView = () => {
       setCount(count + 1);
     }
   };
-
-  const discounted = Math.floor(price * count * 0.9);
-  const totalPoint = point * count;
 
   return (
     <div css={s.Wrapper}>
@@ -59,20 +68,24 @@ const FirstCartView = () => {
         <div css={s.cardHeader}>
           <div css={s.bookTag}>
             <Icon name="check" width={20} height={20} />
-            <span className="title">[국내도서] 단 한 번의 삶</span>
+            <span css={s.titleText}>{bookData?.title ?? ''}</span>
           </div>
           <Icon name="close" width={20} height={20} />
         </div>
 
         <div css={s.cardBody}>
-          <Icon name="cartBook" width={62} height={90} />
+          <img
+            css={s.imageStyle}
+            src={bookData?.imageUrl ?? ''}
+            alt={`책 대표 이미지 - ${bookData?.title}`}
+          />
           <div className="priceSection">
             <div className="priceBox">
               <p className="discount">10%</p>
-              <p className="finalPrice">{discounted.toLocaleString()}원</p>
+              <p className="finalPrice">{discountedTotalPrice.toLocaleString()}원</p>
               <p className="origin">
-                <span className="originPrice">{(price * count).toLocaleString()}원</span>
-                <span className="point"> ({totalPoint}P)</span>
+                <span className="originPrice">{originalTotalPrice.toLocaleString()}원</span>
+                <span className="point"> ({totalPoint.toLocaleString()}P)</span>
               </p>
             </div>
             <div className="countController">

--- a/src/pages/HomeBestDetailCart/HomeBestDetailCart.tsx
+++ b/src/pages/HomeBestDetailCart/HomeBestDetailCart.tsx
@@ -15,10 +15,12 @@ const HomeBestDetailCart = () => {
   const navigate = useNavigate();
   const { bookId } = useParams<{ bookId: string }>();
 
-  if (!bookId) return <div>잘못된 접근입니다.</div>;
-
-  const numericBookId = Number(bookId);
+  const numericBookId = Number(bookId || '0');
   const { data: bookDetailData } = useGetBookDetail(numericBookId);
+
+  if (!bookId || isNaN(numericBookId)) {
+    return <div>잘못된 접근입니다.</div>;
+  }
 
   const handleBack = () => navigate(`/best/detail/${bookId}`);
   const handleHome = () => navigate(routePath.HOME);

--- a/src/pages/HomeBestDetailCart/HomeBestDetailCart.tsx
+++ b/src/pages/HomeBestDetailCart/HomeBestDetailCart.tsx
@@ -10,6 +10,7 @@ import ThirdCartView from '@/pages/HomeBestDetailCart/ThirdCartView/ThirdCartVie
 import FourthCartView from '@/pages/HomeBestDetailCart/FourthCartView/ForthCartView';
 import routePath from '@/routes/routePath';
 import { useGetBookDetail } from '@/apis/homeBestDetail/queries';
+import { useState } from 'react';
 
 const HomeBestDetailCart = () => {
   const navigate = useNavigate();
@@ -17,6 +18,8 @@ const HomeBestDetailCart = () => {
 
   const numericBookId = Number(bookId || '0');
   const { data: bookDetailData } = useGetBookDetail(numericBookId);
+
+  const [totalPrice, setTotalPrice] = useState(0);
 
   if (!bookId || isNaN(numericBookId)) {
     return <div>잘못된 접근입니다.</div>;
@@ -72,13 +75,13 @@ const HomeBestDetailCart = () => {
       </div>
 
       <main css={s.Body}>
-        <FirstCartView bookData={bookDetailData} />
+        <FirstCartView bookData={bookDetailData} onTotalPriceChange={setTotalPrice} />
         <SecondCartView />
         <ThirdCartView />
         <FourthCartView />
       </main>
       <Floater />
-      <CartBottomNav />
+      <CartBottomNav totalPrice={totalPrice} />
     </div>
   );
 };

--- a/src/pages/HomeBestDetailCart/HomeBestDetailCart.tsx
+++ b/src/pages/HomeBestDetailCart/HomeBestDetailCart.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { HomeBestDetailCartStyle as s } from '@/pages/HomeBestDetailCart/HomeBestDetailCart.style';
 import Icon from '@/components/Icon';
@@ -9,11 +9,18 @@ import SecondCartView from '@/pages/HomeBestDetailCart/SecondCartView/SecondCart
 import ThirdCartView from '@/pages/HomeBestDetailCart/ThirdCartView/ThirdCartView';
 import FourthCartView from '@/pages/HomeBestDetailCart/FourthCartView/ForthCartView';
 import routePath from '@/routes/routePath';
+import { useGetBookDetail } from '@/apis/homeBestDetail/queries';
 
 const HomeBestDetailCart = () => {
   const navigate = useNavigate();
+  const { bookId } = useParams<{ bookId: string }>();
 
-  const handleBack = () => navigate(routePath.HOME_BEST_DETAIL);
+  if (!bookId) return <div>잘못된 접근입니다.</div>;
+
+  const numericBookId = Number(bookId);
+  const { data: bookDetailData } = useGetBookDetail(numericBookId);
+
+  const handleBack = () => navigate(`/best/detail/${bookId}`);
   const handleHome = () => navigate(routePath.HOME);
 
   return (
@@ -63,7 +70,7 @@ const HomeBestDetailCart = () => {
       </div>
 
       <main css={s.Body}>
-        <FirstCartView />
+        <FirstCartView bookData={bookDetailData} />
         <SecondCartView />
         <ThirdCartView />
         <FourthCartView />

--- a/src/pages/HomeBestDetailCart/ThirdCartView/ThirdCartView.tsx
+++ b/src/pages/HomeBestDetailCart/ThirdCartView/ThirdCartView.tsx
@@ -49,7 +49,7 @@ const mockRectangularCards = [
 const ThirdCartView = () => {
   return (
     <div css={s.Wrapper}>
-      <h3 css={s.title}>이런 상품은 어떠세요?</h3>
+      <h3 css={s.title}>책이 더 좋아지게 만드는 작은 취향</h3>
 
       <HorizontalScrollList gap="1.2rem" sidePadding="0rem">
         {mockSquareCards.map((card, idx) => (
@@ -59,6 +59,7 @@ const ThirdCartView = () => {
         ))}
       </HorizontalScrollList>
 
+      <h3 css={s.title}>‘요즘 나'에게 필요한 지혜와 위로</h3>
       <HorizontalScrollList gap="1.2rem" sidePadding="0rem">
         {mockRectangularCards.map((card, idx) => (
           <div key={idx} css={s.cardWrapper}>

--- a/src/routes/routePath.ts
+++ b/src/routes/routePath.ts
@@ -2,5 +2,5 @@ export default {
   HOME: '/',
   HOME_BEST: '/best',
   HOME_BEST_DETAIL: '/best/detail/:bookId',
-  HOME_BEST_DETAIL_CART: '/best/detail-cart',
+  HOME_BEST_DETAIL_CART: '/best/detail-cart/:bookId',
 };


### PR DESCRIPTION
## 📌 이슈 번호
- close #105 

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR 템플릿 작성
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 구현 사항
-  HomeBestDetailCart 페이지 Api 연동
- 라우트 수정


## 🔍 Review Point
- 확인해봤을 때 에러는 크게 없고, api도 정상 작동 합니다!! 다만 라우트 경로를 bookid에 맞게 
`HOME_BEST_DETAIL_CART: '/best/detail-cart` 에서  `HOME_BEST_DETAIL_CART: '/best/detail-cart/:bookId'`로 수정해서
확인 한번만 해주세요!
- 추가적으로 장바구니 페이지 바텀네비바 가격이 고정되어 있었는데, 장바구니 페이지에서 물건을  -/+ 버튼을 누르면 변동하는 가격대로 변경이 가능하도록 구현 완료 해놨습니다! 
- 3번은 테스트 해봐서 아마 문제 없을겁니당 
- 수고했다 교보문고!!!!!!!!!!!!!!!!



## 📸 Screenshot
![image](https://github.com/user-attachments/assets/31669fd8-f8fb-4aa9-90dd-72b01a0fd93b)
![image](https://github.com/user-attachments/assets/65870fd9-b05c-4d4b-9c2c-748ac61b9c53)
![image](https://github.com/user-attachments/assets/fded5b37-6b0c-4c6e-9b3c-a531638e8c1d)
![image](https://github.com/user-attachments/assets/29fa3f59-c78f-426c-93b6-5c4ffc9e37d5)
![image](https://github.com/user-attachments/assets/a606238c-3e63-484c-95d2-1f07a285f74d)
